### PR TITLE
Compatibility with WordPress up to version 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: blog, accessibility-ready, custom-logo, custom-menu, custom-colors, editor
 Requires at least: 6.0
 Stable tag: 1.3.0
 Version: 1.3.0
-Tested up to: 6.8
+Tested up to: 7.0
 Requires PHP: 7.4
 License: GPL v3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Update readme.txt to reflect compatibility with WordPress 7.0 by changing the "Tested up to" header from 6.8 to 7.0. No code or functionality changes.